### PR TITLE
feat: read CZI files from http/https URLs

### DIFF
--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -102,7 +102,8 @@ jobs:
       - uses: pypa/cibuildwheel@v2.23.4
         env:
           CIBW_BUILD: "*-${{ matrix.cibw-arch }}"
-          CIBW_BEFORE_ALL_LINUX: yum install -y zlib-devel libpng-devel
+          # openssl-devel gives the bundled libcurl a TLS backend; without it https URLs fail.
+          CIBW_BEFORE_ALL_LINUX: yum install -y zlib-devel libpng-devel openssl-devel
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest {project}/aicspylibczi/tests
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -102,7 +102,6 @@ jobs:
       - uses: pypa/cibuildwheel@v2.23.4
         env:
           CIBW_BUILD: "*-${{ matrix.cibw-arch }}"
-          # openssl-devel gives the bundled libcurl a TLS backend; without it https URLs fail.
           CIBW_BEFORE_ALL_LINUX: yum install -y zlib-devel libpng-devel openssl-devel
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest {project}/aicspylibczi/tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,33 +33,25 @@ SET(pybind11_DIR ${CMAKE_CURRENT_LIST_DIR}/pybind11)
 
 add_compile_definitions(_LIBCZISTATICLIB)
 
-# Turn off the parts of libCZI we do not link against. These must be cache variables because
-# libCZI declares them with option(); as add_compile_definitions() they only became -D
-# preprocessor flags and left the options at their defaults, so every build was fetching
-# googletest from GitHub and compiling libCZI's whole test suite and its dynamic library.
-# The googletest download made configure fail whenever GitHub returned a 503.
+# libCZI declares these with option(), so they must be set as cache variables --
+# add_compile_definitions() leaves the options at their defaults.
 set(LIBCZI_BUILD_UNITTESTS OFF CACHE BOOL "" FORCE)
 set(LIBCZI_BUILD_DYNLIB OFF CACHE BOOL "" FORCE)
 set(LIBCZI_BUILD_CZICMD OFF CACHE BOOL "" FORCE)
 
-# Build libCZI's curl-based http/https stream class so CZI files can be read from URLs.
-# These must be cache variables because libCZI declares them with option().
+# curl-based http/https stream class, statically linked against a libCZI-pinned libcurl
 set(LIBCZI_BUILD_CURL_BASED_STREAM ON CACHE BOOL "" FORCE)
-# OFF makes libCZI fetch and statically link a pinned libcurl, keeping wheels self-contained.
 set(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL OFF CACHE BOOL "" FORCE)
 
 IF (APPLE)
-    # Use Apple's Secure Transport for TLS rather than OpenSSL. curl's CMake picks up a
-    # Homebrew OpenSSL when it can find one, which is not redistributable in a wheel and is
-    # single-architecture, so it breaks the universal2 build. Secure Transport needs no
-    # external dependency and uses the system trust store.
+    # Secure Transport rather than OpenSSL: a Homebrew OpenSSL is neither redistributable
+    # nor universal2, so curl finding one breaks the wheel.
     set(CURL_USE_SECTRANSP ON CACHE BOOL "" FORCE)
     set(CURL_USE_OPENSSL OFF CACHE BOOL "" FORCE)
 ENDIF(APPLE)
 
-# Pin off curl's optional dependencies. They are auto-detected, so without this the wheel
-# picks up whatever happens to be installed on the build machine - libidn2 from Homebrew,
-# for example, which is not redistributable. None are needed to issue range-request GETs.
+# curl's optional dependencies are auto-detected, so pin them off or the wheel picks up
+# whatever the build machine happens to have. None are needed for range-request GETs.
 set(USE_LIBIDN2 OFF CACHE BOOL "" FORCE)
 set(CURL_USE_LIBPSL OFF CACHE BOOL "" FORCE)
 set(CURL_USE_LIBSSH2 OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,34 @@ add_compile_definitions(_LIBCZISTATICLIB)
 add_compile_definitions(LIBCZI_BUILD_UNITTESTS=OFF)
 add_compile_definitions(LIBCZI_BUILD_DYNLIB=OFF)
 add_compile_definitions(LIBCZI_BUILD_CZICMD=OFF)
+
+# Build libCZI's curl-based http/https stream class so CZI files can be read from URLs.
+# These must be cache variables because libCZI declares them with option().
+set(LIBCZI_BUILD_CURL_BASED_STREAM ON CACHE BOOL "" FORCE)
+# OFF makes libCZI fetch and statically link a pinned libcurl, keeping wheels self-contained.
+set(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL OFF CACHE BOOL "" FORCE)
+
+IF (APPLE)
+    # Use Apple's Secure Transport for TLS rather than OpenSSL. curl's CMake picks up a
+    # Homebrew OpenSSL when it can find one, which is not redistributable in a wheel and is
+    # single-architecture, so it breaks the universal2 build. Secure Transport needs no
+    # external dependency and uses the system trust store.
+    set(CURL_USE_SECTRANSP ON CACHE BOOL "" FORCE)
+    set(CURL_USE_OPENSSL OFF CACHE BOOL "" FORCE)
+ENDIF(APPLE)
+
+# Pin off curl's optional dependencies. They are auto-detected, so without this the wheel
+# picks up whatever happens to be installed on the build machine - libidn2 from Homebrew,
+# for example, which is not redistributable. None are needed to issue range-request GETs.
+set(USE_LIBIDN2 OFF CACHE BOOL "" FORCE)
+set(CURL_USE_LIBPSL OFF CACHE BOOL "" FORCE)
+set(CURL_USE_LIBSSH2 OFF CACHE BOOL "" FORCE)
+set(USE_NGHTTP2 OFF CACHE BOOL "" FORCE)
+set(CURL_BROTLI OFF CACHE BOOL "" FORCE)
+set(CURL_ZSTD OFF CACHE BOOL "" FORCE)
+set(CURL_DISABLE_LDAP ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_LDAPS ON CACHE BOOL "" FORCE)
+
 add_subdirectory(libCZI)
 add_subdirectory(pybind11)
 
@@ -44,16 +72,17 @@ set(PYLIBCZI_C_SRC_HEADERS _aicspylibczi/Reader.h _aicspylibczi/helper_algorithm
         _aicspylibczi/IndexMap.h _aicspylibczi/Image.h _aicspylibczi/TypedImage.h _aicspylibczi/ImageFactory.h
         _aicspylibczi/SourceRange.h _aicspylibczi/TargetRange.h _aicspylibczi/pylibczi_ostream.h
         _aicspylibczi/SubblockMetaVec.h _aicspylibczi/DimIndex.h _aicspylibczi/constants.h
-        _aicspylibczi/StreamImplLockingRead.h _aicspylibczi/Threadpool.h)
+        _aicspylibczi/StreamImplLockingRead.h _aicspylibczi/Threadpool.h _aicspylibczi/UrlStream.h)
 
 set(PYLIBCZI_C_SRC _aicspylibczi/Reader.cpp _aicspylibczi/IndexMap.cpp _aicspylibczi/Image.cpp _aicspylibczi/ImageFactory.cpp
         _aicspylibczi/pylibczi_ostream.cpp _aicspylibczi/exceptions.cpp _aicspylibczi/SubblockSortable.h
         _aicspylibczi/pb_caster_SubblockMetaVec.h _aicspylibczi/constants.cpp _aicspylibczi/DimIndex.cpp
-        _aicspylibczi/StreamImplLockingRead.cpp)
+        _aicspylibczi/StreamImplLockingRead.cpp _aicspylibczi/UrlStream.cpp)
 
 set(PYLIBCZI_PYBIND11 _aicspylibczi/pb_bindings.cpp _aicspylibczi/pb_helpers.h _aicspylibczi/pb_helpers.cpp _aicspylibczi/pb_caster_ImagesContainer.h
         _aicspylibczi/pb_caster_BytesIO.h _aicspylibczi/pb_caster_libCZI_DimensionIndex.h _aicspylibczi/CSimpleStreamImplFromFd.h
-        _aicspylibczi/CSimpleStreamImplFromFd.cpp _aicspylibczi/pb_caster_DimIndex.h)
+        _aicspylibczi/CSimpleStreamImplFromFd.cpp _aicspylibczi/pb_caster_DimIndex.h
+        _aicspylibczi/pb_stream_options.h)
 
 set(TARGET_ONE libczi_c++_extension)
 set(TARGET_TWO _aicspylibczi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,15 @@ ENDIF(WIN32)
 SET(pybind11_DIR ${CMAKE_CURRENT_LIST_DIR}/pybind11)
 
 add_compile_definitions(_LIBCZISTATICLIB)
-add_compile_definitions(LIBCZI_BUILD_UNITTESTS=OFF)
-add_compile_definitions(LIBCZI_BUILD_DYNLIB=OFF)
-add_compile_definitions(LIBCZI_BUILD_CZICMD=OFF)
+
+# Turn off the parts of libCZI we do not link against. These must be cache variables because
+# libCZI declares them with option(); as add_compile_definitions() they only became -D
+# preprocessor flags and left the options at their defaults, so every build was fetching
+# googletest from GitHub and compiling libCZI's whole test suite and its dynamic library.
+# The googletest download made configure fail whenever GitHub returned a 503.
+set(LIBCZI_BUILD_UNITTESTS OFF CACHE BOOL "" FORCE)
+set(LIBCZI_BUILD_DYNLIB OFF CACHE BOOL "" FORCE)
+set(LIBCZI_BUILD_CZICMD OFF CACHE BOOL "" FORCE)
 
 # Build libCZI's curl-based http/https stream class so CZI files can be read from URLs.
 # These must be cache variables because libCZI declares them with option().

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,12 @@ SET(pybind11_DIR ${CMAKE_CURRENT_LIST_DIR}/pybind11)
 
 add_compile_definitions(_LIBCZISTATICLIB)
 
-# libCZI declares these with option(), so they must be set as cache variables --
-# add_compile_definitions() leaves the options at their defaults.
+
 set(LIBCZI_BUILD_UNITTESTS OFF CACHE BOOL "" FORCE)
 set(LIBCZI_BUILD_DYNLIB OFF CACHE BOOL "" FORCE)
 set(LIBCZI_BUILD_CZICMD OFF CACHE BOOL "" FORCE)
 
-# curl-based http/https stream class, statically linked against a libCZI-pinned libcurl
+# curl-based http/https stream class
 set(LIBCZI_BUILD_CURL_BASED_STREAM ON CACHE BOOL "" FORCE)
 set(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL OFF CACHE BOOL "" FORCE)
 
@@ -50,8 +49,6 @@ IF (APPLE)
     set(CURL_USE_OPENSSL OFF CACHE BOOL "" FORCE)
 ENDIF(APPLE)
 
-# curl's optional dependencies are auto-detected, so pin them off or the wheel picks up
-# whatever the build machine happens to have. None are needed for range-request GETs.
 set(USE_LIBIDN2 OFF CACHE BOOL "" FORCE)
 set(CURL_USE_LIBPSL OFF CACHE BOOL "" FORCE)
 set(CURL_USE_LIBSSH2 OFF CACHE BOOL "" FORCE)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,62 @@ img = Image.fromarray(normed_mosaic_data.astype(np.uint8))
 
 ![Mosaic Image](images/mosaic.png)
 
+#### Example 3: Read a czi from a remote URL
+
+`CziFile` accepts `http` and `https` URLs in place of a path. Reads are served by libCZI's
+libcurl-backed stream, which fetches only the byte ranges it needs rather than downloading
+the whole file, so tile and plane access stays cheap on large remote images.
+
+```python
+from aicspylibczi import CziFile
+
+czi = CziFile("https://example.com/data/mosaic_file.czi")
+
+czi.dims  # 'BSCZYX'
+img, shp = czi.read_image(S=0, C=0)
+```
+
+The server must support HTTP range requests. If it does not, libCZI cannot read the file.
+
+Pass `stream_options` to configure the underlying curl stream, for example to set a timeout
+or send a bearer token to an authenticated endpoint:
+
+```python
+czi = CziFile(
+    "https://example.com/data/image.czi",
+    stream_options={
+        "timeout": 60,             # seconds for the whole transfer
+        "connect_timeout": 10,     # seconds for the connection phase
+        "xoauth2_bearer": token,   # OAuth2 access token
+    },
+)
+```
+
+Option names are libCZI's stream properties. Both the full name (`CurlHttp_Timeout`) and its
+short form (`timeout`) are accepted, case- and underscore-insensitively. The full set for your
+installation is available programmatically:
+
+```python
+import _aicspylibczi
+
+_aicspylibczi.stream_option_names()
+# ['CurlHttp_Proxy', 'CurlHttp_UserAgent', 'CurlHttp_Timeout', 'CurlHttp_ConnectTimeout',
+#  'CurlHttp_Xoauth2Bearer', 'CurlHttp_Cookie', 'CurlHttp_SslVerifyPeer', 'CurlHttp_SslVerifyHost',
+#  'CurlHttp_FollowLocation', 'CurlHttp_MaxRedirs', 'CurlHttp_CaInfo', 'CurlHttp_CaInfoBlob']
+```
+
+Remote reads depend on a build-time option, so a build made without the curl stream will
+reject URLs. Check before relying on it:
+
+```python
+from aicspylibczi import remote_reads_available
+
+remote_reads_available()  # True for the published wheels
+```
+
+Object stores that issue presigned URLs (S3, GCS, Azure Blob) work through the same path,
+since a presigned URL is just an authenticated https URL.
+
 ## Installation
 
 The preferred installation method is with `pip install`.
@@ -127,6 +183,10 @@ Use these steps to build and install aicspylibczi locally:
 - Requirements:
   - libCZI requires a c++11 compatible compiler. Built & Tested with clang.
   - Development requirements are those required for libCZI: **libpng**, **zlib**
+  - libcurl is fetched and built automatically to support remote reads. On Linux it needs a TLS
+    backend present at build time (**openssl-devel** / **libssl-dev**) or `https` URLs will not
+    work. macOS uses Secure Transport and Windows uses SChannel, neither of which needs anything
+    installed.
   - Install the package:
     ```
     pip install .

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -222,8 +222,7 @@ Reader::getAllSceneYXSize(int scene_index_, bool get_all_matches_)
     if (hasScene) {
       x.first.coordinatePtr()->TryGetPosition(libCZI::DimensionIndex::S, &embeddedSceneIndex);
       if (embeddedSceneIndex == scene_index_) {
-        // Only the logicalRect is wanted, and that comes from the subblock directory -- reading the
-        // subblock itself would fetch a tile's worth of pixels to answer a question about geometry.
+        // the directory has the logicalRect, reading the subblock would fetch the pixels too
         libCZI::SubBlockInfo sbkInfo;
         if (!m_czireader->TryGetSubBlockInfo(x.second, &sbkInfo))
           continue;
@@ -299,9 +298,7 @@ Reader::readSelected(libCZI::CDimCoordinate& plane_coord_,
                                              "Scenes must be read individually "
                                              "for this file, scenes have inconsistent YX shapes!");
   }
-  // A region of {0, 0, -1, -1} (the default) means "no spatial constraint". Anything else is
-  // validated against the file and then handed to getMatches, which drops non-intersecting
-  // subblocks before they are ever read from the stream.
+  // the default region of {0, 0, -1, -1} means no spatial constraint
   bool hasRegion = (region_.w > 0 && region_.h > 0);
   if (hasRegion)
     isValidRegion(region_, m_statistics.boundingBox); // if not throws RegionSelectionException
@@ -310,8 +307,7 @@ Reader::readSelected(libCZI::CDimCoordinate& plane_coord_,
   // SubblockIndexVec is actually a set this is crucial to preserve the image order
   SubblockIndexVec matches = getMatches(subblocksToFind, hasRegion ? &region_ : nullptr);
   if (matches.empty()) {
-    // getMatches only diagnoses bad dimension constraints; an empty set here means the region
-    // itself selected nothing, which it cannot detect.
+    // getMatches faults bad dimension constraints, so getting here means the region selected nothing
     throw RegionSelectionException(region_, m_statistics.boundingBox, "No subblocks intersect the requested region!");
   }
   m_pixelType = matches.begin()->first.pixelType();
@@ -393,8 +389,7 @@ Reader::readSubblockMeta(libCZI::CDimCoordinate& plane_coord_, int index_m_)
 
 // private methods
 
-// Two rectangles intersect only if the overlap has a non-zero area, so tiles that merely touch the
-// region's edge are excluded. This matches how libCZI itself filters a directory by ROI.
+// a zero-area overlap doesn't count, so tiles that only touch the region's edge are excluded
 static bool
 doIntersect(const libCZI::IntRect& a_, const libCZI::IntRect& b_)
 {
@@ -412,18 +407,13 @@ Reader::getMatches(SubblockSortable& match_, const libCZI::IntRect* region_)
   m_czireader->EnumerateSubBlocks([&](int index_, const libCZI::SubBlockInfo& info_) -> bool {
     SubblockSortable subInfo(&(info_.coordinate), info_.mIndex, isMosaic(), info_.pixelType);
     if (isPyramid0(info_) && match_ == subInfo) {
-      // logicalRect comes from the subblock directory, which was parsed when the file was
-      // opened, so rejecting a subblock here costs no I/O.
+      // logicalRect is already in memory from the subblock directory, so this rejection costs no I/O
       if (region_ == nullptr || doIntersect(*region_, info_.logicalRect))
         ans.emplace(std::pair<SubblockSortable, int>(subInfo, index_));
     }
     return true; // Enumerate through every subblock
   });
 
-  // The checks below only fault genuinely invalid dimension constraints, so they stay useful when a
-  // region is in play: a caller who passes both a bad dimension and a region still hears about the
-  // dimension. An empty result that survives them means the region simply selected nothing, which is
-  // the caller's business to interpret.
   if (ans.empty()) {
     // check for invalid Dimension specification
     match_.coordinatePtr()->EnumValidDimensions([&](libCZI::DimensionIndex di_, int value_) {
@@ -547,8 +537,7 @@ Reader::tileBoundingBoxesWith(SubblockSortable& subblocksToFind_)
     throw CDimCoordinatesOverspecifiedException("Tile dimensions overspecified, no matching tiles found.");
 
   auto extractor = [&](const SubblockIndexVec::value_type& match_) {
-    // The rectangle lives in the subblock directory, so ask for the info rather than reading the
-    // subblock: reading it would pull every tile's pixels over the wire for a remote file.
+    // the directory has the logicalRect, reading the subblock would fetch the pixels too
     libCZI::SubBlockInfo sbkInfo;
     if (!m_czireader->TryGetSubBlockInfo(match_.second, &sbkInfo))
       throw ImageAccessUnderspecifiedException(0, 1, "Subblock index not found while reading tile bounding boxes.");

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -222,7 +222,6 @@ Reader::getAllSceneYXSize(int scene_index_, bool get_all_matches_)
     if (hasScene) {
       x.first.coordinatePtr()->TryGetPosition(libCZI::DimensionIndex::S, &embeddedSceneIndex);
       if (embeddedSceneIndex == scene_index_) {
-        // the directory has the logicalRect, reading the subblock would fetch the pixels too
         libCZI::SubBlockInfo sbkInfo;
         if (!m_czireader->TryGetSubBlockInfo(x.second, &sbkInfo))
           continue;
@@ -298,16 +297,14 @@ Reader::readSelected(libCZI::CDimCoordinate& plane_coord_,
                                              "Scenes must be read individually "
                                              "for this file, scenes have inconsistent YX shapes!");
   }
-  // the default region of {0, 0, -1, -1} means no spatial constraint
   bool hasRegion = (region_.w > 0 && region_.h > 0);
   if (hasRegion)
-    isValidRegion(region_, m_statistics.boundingBox); // if not throws RegionSelectionException
+    isValidRegion(region_, m_statistics.boundingBox);
 
   SubblockSortable subblocksToFind(&plane_coord_, index_m_, isMosaic());
   // SubblockIndexVec is actually a set this is crucial to preserve the image order
   SubblockIndexVec matches = getMatches(subblocksToFind, hasRegion ? &region_ : nullptr);
   if (matches.empty()) {
-    // getMatches faults bad dimension constraints, so getting here means the region selected nothing
     throw RegionSelectionException(region_, m_statistics.boundingBox, "No subblocks intersect the requested region!");
   }
   m_pixelType = matches.begin()->first.pixelType();
@@ -389,7 +386,6 @@ Reader::readSubblockMeta(libCZI::CDimCoordinate& plane_coord_, int index_m_)
 
 // private methods
 
-// a zero-area overlap doesn't count, so tiles that only touch the region's edge are excluded
 static bool
 doIntersect(const libCZI::IntRect& a_, const libCZI::IntRect& b_)
 {
@@ -407,7 +403,6 @@ Reader::getMatches(SubblockSortable& match_, const libCZI::IntRect* region_)
   m_czireader->EnumerateSubBlocks([&](int index_, const libCZI::SubBlockInfo& info_) -> bool {
     SubblockSortable subInfo(&(info_.coordinate), info_.mIndex, isMosaic(), info_.pixelType);
     if (isPyramid0(info_) && match_ == subInfo) {
-      // logicalRect is already in memory from the subblock directory, so this rejection costs no I/O
       if (region_ == nullptr || doIntersect(*region_, info_.logicalRect))
         ans.emplace(std::pair<SubblockSortable, int>(subInfo, index_));
     }
@@ -537,7 +532,6 @@ Reader::tileBoundingBoxesWith(SubblockSortable& subblocksToFind_)
     throw CDimCoordinatesOverspecifiedException("Tile dimensions overspecified, no matching tiles found.");
 
   auto extractor = [&](const SubblockIndexVec::value_type& match_) {
-    // the directory has the logicalRect, reading the subblock would fetch the pixels too
     libCZI::SubBlockInfo sbkInfo;
     if (!m_czireader->TryGetSubBlockInfo(match_.second, &sbkInfo))
       throw ImageAccessUnderspecifiedException(0, 1, "Subblock index not found while reading tile bounding boxes.");

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -222,9 +222,11 @@ Reader::getAllSceneYXSize(int scene_index_, bool get_all_matches_)
     if (hasScene) {
       x.first.coordinatePtr()->TryGetPosition(libCZI::DimensionIndex::S, &embeddedSceneIndex);
       if (embeddedSceneIndex == scene_index_) {
-        int index = x.second;
-        auto subblk = m_czireader->ReadSubBlock(index);
-        auto sbkInfo = subblk->GetSubBlockInfo();
+        // Only the logicalRect is wanted, and that comes from the subblock directory -- reading the
+        // subblock itself would fetch a tile's worth of pixels to answer a question about geometry.
+        libCZI::SubBlockInfo sbkInfo;
+        if (!m_czireader->TryGetSubBlockInfo(x.second, &sbkInfo))
+          continue;
         result.emplace_back(sbkInfo.logicalRect);
         if (!get_all_matches_)
           return result;
@@ -285,7 +287,10 @@ Reader::dimsString()
 }
 
 std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector<std::pair<char, size_t>>>
-Reader::readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_, unsigned int cores_)
+Reader::readSelected(libCZI::CDimCoordinate& plane_coord_,
+                     int index_m_,
+                     unsigned int cores_,
+                     libCZI::IntRect region_)
 {
   int pos;
   if (m_specifyScene && !plane_coord_.TryGetPosition(libCZI::DimensionIndex::S, &pos)) {
@@ -294,9 +299,21 @@ Reader::readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_, unsigne
                                              "Scenes must be read individually "
                                              "for this file, scenes have inconsistent YX shapes!");
   }
+  // A region of {0, 0, -1, -1} (the default) means "no spatial constraint". Anything else is
+  // validated against the file and then handed to getMatches, which drops non-intersecting
+  // subblocks before they are ever read from the stream.
+  bool hasRegion = (region_.w > 0 && region_.h > 0);
+  if (hasRegion)
+    isValidRegion(region_, m_statistics.boundingBox); // if not throws RegionSelectionException
+
   SubblockSortable subblocksToFind(&plane_coord_, index_m_, isMosaic());
   // SubblockIndexVec is actually a set this is crucial to preserve the image order
-  SubblockIndexVec matches = getMatches(subblocksToFind);
+  SubblockIndexVec matches = getMatches(subblocksToFind, hasRegion ? &region_ : nullptr);
+  if (matches.empty()) {
+    // getMatches only diagnoses bad dimension constraints; an empty set here means the region
+    // itself selected nothing, which it cannot detect.
+    throw RegionSelectionException(region_, m_statistics.boundingBox, "No subblocks intersect the requested region!");
+  }
   m_pixelType = matches.begin()->first.pixelType();
   size_t bgrScaling = ImageFactory::numberOfSamples(m_pixelType);
 
@@ -376,18 +393,37 @@ Reader::readSubblockMeta(libCZI::CDimCoordinate& plane_coord_, int index_m_)
 
 // private methods
 
+// Two rectangles intersect only if the overlap has a non-zero area, so tiles that merely touch the
+// region's edge are excluded. This matches how libCZI itself filters a directory by ROI.
+static bool
+doIntersect(const libCZI::IntRect& a_, const libCZI::IntRect& b_)
+{
+  int x0 = std::max(a_.x, b_.x);
+  int y0 = std::max(a_.y, b_.y);
+  int x1 = std::min(a_.x + a_.w, b_.x + b_.w);
+  int y1 = std::min(a_.y + a_.h, b_.y + b_.h);
+  return (x1 > x0 && y1 > y0);
+}
+
 Reader::SubblockIndexVec
-Reader::getMatches(SubblockSortable& match_)
+Reader::getMatches(SubblockSortable& match_, const libCZI::IntRect* region_)
 {
   SubblockIndexVec ans;
   m_czireader->EnumerateSubBlocks([&](int index_, const libCZI::SubBlockInfo& info_) -> bool {
     SubblockSortable subInfo(&(info_.coordinate), info_.mIndex, isMosaic(), info_.pixelType);
     if (isPyramid0(info_) && match_ == subInfo) {
-      ans.emplace(std::pair<SubblockSortable, int>(subInfo, index_));
+      // logicalRect comes from the subblock directory, which was parsed when the file was
+      // opened, so rejecting a subblock here costs no I/O.
+      if (region_ == nullptr || doIntersect(*region_, info_.logicalRect))
+        ans.emplace(std::pair<SubblockSortable, int>(subInfo, index_));
     }
     return true; // Enumerate through every subblock
   });
 
+  // The checks below only fault genuinely invalid dimension constraints, so they stay useful when a
+  // region is in play: a caller who passes both a bad dimension and a region still hears about the
+  // dimension. An empty result that survives them means the region simply selected nothing, which is
+  // the caller's business to interpret.
   if (ans.empty()) {
     // check for invalid Dimension specification
     match_.coordinatePtr()->EnumValidDimensions([&](libCZI::DimensionIndex di_, int value_) {
@@ -511,8 +547,11 @@ Reader::tileBoundingBoxesWith(SubblockSortable& subblocksToFind_)
     throw CDimCoordinatesOverspecifiedException("Tile dimensions overspecified, no matching tiles found.");
 
   auto extractor = [&](const SubblockIndexVec::value_type& match_) {
-    auto subblk = m_czireader->ReadSubBlock(match_.second);
-    auto sbkInfo = subblk->GetSubBlockInfo();
+    // The rectangle lives in the subblock directory, so ask for the info rather than reading the
+    // subblock: reading it would pull every tile's pixels over the wire for a remote file.
+    libCZI::SubBlockInfo sbkInfo;
+    if (!m_czireader->TryGetSubBlockInfo(match_.second, &sbkInfo))
+      throw ImageAccessUnderspecifiedException(0, 1, "Subblock index not found while reading tile bounding boxes.");
     return TileBBoxMap::value_type(match_.first, sbkInfo.logicalRect);
   };
 

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -298,8 +298,9 @@ Reader::readSelected(libCZI::CDimCoordinate& plane_coord_,
                                              "for this file, scenes have inconsistent YX shapes!");
   }
   bool hasRegion = (region_.w > 0 && region_.h > 0);
-  if (hasRegion)
+  if (hasRegion) {
     isValidRegion(region_, m_statistics.boundingBox);
+  }
 
   SubblockSortable subblocksToFind(&plane_coord_, index_m_, isMosaic());
   // SubblockIndexVec is actually a set this is crucial to preserve the image order

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -207,13 +207,10 @@ public:
    * @param plane_coord_ A structure containing the Dimension constraints
    * @param index_m_ Is only relevant for mosaic files, if you wish to select one frame.
    * @param cores_ The number of cores to use to process threads
-   * @param region_ (optional) The {x0, y0, width, height} of a sub-region, in the file's global pixel
-   * coordinate frame (the same frame as read_mosaic's region and as the tile bounding boxes). Subblocks
-   * that do not intersect it are skipped without being read, so for a file being read over the network
-   * their bytes never cross the wire. The default {0, 0, -1, -1} means every matching subblock.
-   *
-   * Note that subblocks are the unit of selection, not pixels: a subblock that merely clips the region
-   * is still returned whole. The saving is in the subblocks not read at all.
+   * @param region_ (optional) The {x0, y0, width, height} of a sub-region, in the same global pixel frame
+   * as readMosaic's region and the tile bounding boxes. Subblocks that do not intersect it are skipped
+   * without being read. Selection is by subblock and not by pixel, so a subblock that merely clips the
+   * region is still returned whole. The default {0, 0, -1, -1} means every matching subblock.
    */
   std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector<std::pair<char, size_t>>>
   readSelected(libCZI::CDimCoordinate& plane_coord_,
@@ -343,13 +340,7 @@ public:
   }
 
 private:
-  /*!
-   * @brief Find the subblocks matching a set of dimension constraints.
-   * @param match_ The dimension constraints to match against
-   * @param region_ (optional) If given, only subblocks whose logicalRect intersects this rectangle are
-   * returned. The test runs against the in-memory subblock directory, so a rejected subblock is never
-   * read from the stream.
-   */
+  // region_, if given, drops subblocks whose logicalRect does not intersect it
   Reader::SubblockIndexVec getMatches(SubblockSortable& match_, const libCZI::IntRect* region_ = nullptr);
 
   static bool isPyramid0(const libCZI::SubBlockInfo& info_)

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -206,9 +206,20 @@ public:
    *
    * @param plane_coord_ A structure containing the Dimension constraints
    * @param index_m_ Is only relevant for mosaic files, if you wish to select one frame.
+   * @param cores_ The number of cores to use to process threads
+   * @param region_ (optional) The {x0, y0, width, height} of a sub-region, in the file's global pixel
+   * coordinate frame (the same frame as read_mosaic's region and as the tile bounding boxes). Subblocks
+   * that do not intersect it are skipped without being read, so for a file being read over the network
+   * their bytes never cross the wire. The default {0, 0, -1, -1} means every matching subblock.
+   *
+   * Note that subblocks are the unit of selection, not pixels: a subblock that merely clips the region
+   * is still returned whole. The saving is in the subblocks not read at all.
    */
   std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector<std::pair<char, size_t>>>
-  readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_ = -1, unsigned int cores_ = 3);
+  readSelected(libCZI::CDimCoordinate& plane_coord_,
+               int index_m_ = -1,
+               unsigned int cores_ = 3,
+               libCZI::IntRect region_ = { 0, 0, -1, -1 });
 
   /*!
    * @brief provide the subblock metadata in index order consistent with readSelected.
@@ -332,7 +343,14 @@ public:
   }
 
 private:
-  Reader::SubblockIndexVec getMatches(SubblockSortable& match_);
+  /*!
+   * @brief Find the subblocks matching a set of dimension constraints.
+   * @param match_ The dimension constraints to match against
+   * @param region_ (optional) If given, only subblocks whose logicalRect intersects this rectangle are
+   * returned. The test runs against the in-memory subblock directory, so a rejected subblock is never
+   * read from the stream.
+   */
+  Reader::SubblockIndexVec getMatches(SubblockSortable& match_, const libCZI::IntRect* region_ = nullptr);
 
   static bool isPyramid0(const libCZI::SubBlockInfo& info_)
   {

--- a/_aicspylibczi/UrlStream.cpp
+++ b/_aicspylibczi/UrlStream.cpp
@@ -11,7 +11,6 @@ const char* kCurlHttpStreamClass = "curl_http_inputstream";
 
 namespace {
 
-/// Lowercase and drop underscores so that "connect_timeout" and "ConnectTimeout" compare equal.
 std::string
 squash(const std::string& str_)
 {

--- a/_aicspylibczi/UrlStream.cpp
+++ b/_aicspylibczi/UrlStream.cpp
@@ -1,0 +1,101 @@
+#include "UrlStream.h"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <stdexcept>
+
+namespace pylibczi {
+
+const char* kCurlHttpStreamClass = "curl_http_inputstream";
+
+namespace {
+
+/// Lowercase and drop underscores so that "connect_timeout" and "ConnectTimeout" compare equal.
+std::string
+squash(const std::string& str_)
+{
+  std::string out;
+  out.reserve(str_.size());
+  for (const unsigned char ch : str_) {
+    if (ch != '_') {
+      out.push_back(static_cast<char>(std::tolower(ch)));
+    }
+  }
+  return out;
+}
+
+}
+
+bool
+curlStreamAvailable()
+{
+  const int count = libCZI::StreamsFactory::GetStreamClassesCount();
+  for (int i = 0; i < count; ++i) {
+    libCZI::StreamsFactory::StreamClassInfo info;
+    if (libCZI::StreamsFactory::GetStreamInfoForClass(i, info) && info.class_name == kCurlHttpStreamClass) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void
+throwIfCurlStreamUnavailable()
+{
+  libCZI::StreamsFactory::Initialize();
+  if (!curlStreamAvailable()) {
+    throw std::runtime_error("This build of aicspylibczi cannot read from http/https: "
+                             "libCZI was compiled without its curl-based stream class.");
+  }
+}
+
+std::vector<std::string>
+streamOptionNames()
+{
+  std::vector<std::string> names;
+  int count = 0;
+  const auto* info = libCZI::StreamsFactory::GetStreamPropertyBagPropertyInfo(&count);
+  for (int i = 0; i < count; ++i) {
+    names.emplace_back(info[i].property_name);
+  }
+  return names;
+}
+
+std::pair<int, libCZI::StreamsFactory::Property::Type>
+resolveStreamOption(const std::string& name_)
+{
+  const std::string wanted = squash(name_);
+  int count = 0;
+  const auto* info = libCZI::StreamsFactory::GetStreamPropertyBagPropertyInfo(&count);
+  for (int i = 0; i < count; ++i) {
+    const std::string candidate(info[i].property_name);
+    const auto underscore = candidate.find('_');
+    const bool matches = squash(candidate) == wanted ||
+                         (underscore != std::string::npos && squash(candidate.substr(underscore + 1)) == wanted);
+    if (matches) {
+      return { info[i].property_id, info[i].property_type };
+    }
+  }
+  return { -1, libCZI::StreamsFactory::Property::Type::Invalid };
+}
+
+std::shared_ptr<libCZI::IStream>
+createStreamFromUrl(const std::string& url_, const std::map<int, libCZI::StreamsFactory::Property>& property_bag_)
+{
+  throwIfCurlStreamUnavailable();
+
+  libCZI::StreamsFactory::CreateStreamInfo streamInfo;
+  streamInfo.class_name = kCurlHttpStreamClass;
+  streamInfo.property_bag = property_bag_;
+
+  auto stream = libCZI::StreamsFactory::CreateStream(streamInfo, url_);
+  if (!stream) {
+    std::ostringstream msg;
+    msg << "libCZI could not create an http/https stream for " << url_ << ".";
+    throw std::runtime_error(msg.str());
+  }
+  return stream;
+}
+
+}

--- a/_aicspylibczi/UrlStream.h
+++ b/_aicspylibczi/UrlStream.h
@@ -1,0 +1,59 @@
+#ifndef _AICSPYLIBCZI_URLSTREAM_H
+#define _AICSPYLIBCZI_URLSTREAM_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "inc_libCZI.h"
+
+namespace pylibczi {
+
+/*!
+ * @brief The libCZI stream class that reads over http/https, backed by libcurl.
+ */
+extern const char* kCurlHttpStreamClass;
+
+/*!
+ * @brief Check whether this build can read CZI files over http/https.
+ * @return true if libCZI was compiled with its curl-based stream class.
+ */
+bool curlStreamAvailable();
+
+/*!
+ * @brief Throw a descriptive error if this build cannot read over http/https.
+ */
+void throwIfCurlStreamUnavailable();
+
+/*!
+ * @brief Get the names of the options accepted by createStreamFromUrl.
+ * @return the libCZI property-bag names, ie "CurlHttp_Timeout".
+ */
+std::vector<std::string> streamOptionNames();
+
+/*!
+ * @brief Resolve an option name to its libCZI property-bag key and value type.
+ *
+ * Both the full libCZI name ("CurlHttp_Timeout") and its suffix ("timeout") are accepted,
+ * case-insensitively.
+ *
+ * @param name_ the option name to resolve
+ * @return the property id and type, or {-1, Invalid} if the name is not recognized
+ */
+std::pair<int, libCZI::StreamsFactory::Property::Type> resolveStreamOption(const std::string& name_);
+
+/*!
+ * @brief Create a stream that reads a CZI file from an http/https URL.
+ * @param url_ the URL of the CZI file, in UTF-8
+ * @param property_bag_ libCZI stream properties, ie timeouts and credentials
+ * @return a stream that can be handed to Reader
+ */
+std::shared_ptr<libCZI::IStream> createStreamFromUrl(
+  const std::string& url_,
+  const std::map<int, libCZI::StreamsFactory::Property>& property_bag_);
+
+}
+
+#endif //_AICSPYLIBCZI_URLSTREAM_H

--- a/_aicspylibczi/UrlStream.h
+++ b/_aicspylibczi/UrlStream.h
@@ -11,26 +11,16 @@
 
 namespace pylibczi {
 
-/*!
- * @brief The libCZI stream class that reads over http/https, backed by libcurl.
- */
+/// @brief The libCZI stream class that reads over http/https, backed by libcurl.
 extern const char* kCurlHttpStreamClass;
 
-/*!
- * @brief Check whether this build can read CZI files over http/https.
- * @return true if libCZI was compiled with its curl-based stream class.
- */
+/// @brief True if libCZI was compiled with its curl-based stream class.
 bool curlStreamAvailable();
 
-/*!
- * @brief Throw a descriptive error if this build cannot read over http/https.
- */
+/// @brief Throw a descriptive error if this build cannot read over http/https.
 void throwIfCurlStreamUnavailable();
 
-/*!
- * @brief Get the names of the options accepted by createStreamFromUrl.
- * @return the libCZI property-bag names, ie "CurlHttp_Timeout".
- */
+/// @brief The libCZI property-bag names accepted as stream options, ie "CurlHttp_Timeout".
 std::vector<std::string> streamOptionNames();
 
 /*!
@@ -39,7 +29,6 @@ std::vector<std::string> streamOptionNames();
  * Both the full libCZI name ("CurlHttp_Timeout") and its suffix ("timeout") are accepted,
  * case-insensitively.
  *
- * @param name_ the option name to resolve
  * @return the property id and type, or {-1, Invalid} if the name is not recognized
  */
 std::pair<int, libCZI::StreamsFactory::Property::Type> resolveStreamOption(const std::string& name_);
@@ -48,7 +37,6 @@ std::pair<int, libCZI::StreamsFactory::Property::Type> resolveStreamOption(const
  * @brief Create a stream that reads a CZI file from an http/https URL.
  * @param url_ the URL of the CZI file, in UTF-8
  * @param property_bag_ libCZI stream properties, ie timeouts and credentials
- * @return a stream that can be handed to Reader
  */
 std::shared_ptr<libCZI::IStream> createStreamFromUrl(
   const std::string& url_,

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -46,11 +46,8 @@ PYBIND11_MODULE(_aicspylibczi, m)
         &pylibczi::streamOptionNames,
         "The libCZI property names accepted as stream options by Reader.from_url.");
 
-  // Every Reader call may block reading the stream, which for a remote file means the network.
-  // Reader never touches the Python API - that is confined to the casters, which run outside the guard.
   using ReleaseGil = py::call_guard<py::gil_scoped_release>;
 
-  // must be registered before Reader, pybind11 converts py::arg defaults at .def() time
   py::class_<libCZI::IntRect>(m, "BBox")
     .def(py::init<>())
     .def("__eq__",

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -46,13 +46,11 @@ PYBIND11_MODULE(_aicspylibczi, m)
         &pylibczi::streamOptionNames,
         "The libCZI property names accepted as stream options by Reader.from_url.");
 
-  // Every Reader call releases the GIL: any of them may read from the stream, which for a
-  // remote file means blocking on the network. Reader itself never touches the Python API -
-  // that is confined to the pybind11 casters, which run before and after the guard.
+  // Every Reader call may block reading the stream, which for a remote file means the network.
+  // Reader never touches the Python API - that is confined to the casters, which run outside the guard.
   using ReleaseGil = py::call_guard<py::gil_scoped_release>;
 
-  // BBox is registered before Reader because pybind11 converts py::arg default values at .def()
-  // time, and Reader::read_selected takes a default-valued IntRect region.
+  // must be registered before Reader, pybind11 converts py::arg defaults at .def() time
   py::class_<libCZI::IntRect>(m, "BBox")
     .def(py::init<>())
     .def("__eq__",
@@ -84,8 +82,6 @@ PYBIND11_MODULE(_aicspylibczi, m)
     .def("read_dims_string", &pylibczi::Reader::dimsString, ReleaseGil())
     .def("read_dims_sizes", &pylibczi::Reader::dimSizes, ReleaseGil())
     .def("read_meta", &pylibczi::Reader::readMeta, ReleaseGil())
-    // Defaults are spelled out here so existing three-argument calls keep working now that
-    // readSelected takes a region.
     .def("read_selected",
          &pylibczi::Reader::readSelected,
          py::arg("plane_coord"),

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -1,8 +1,10 @@
+#include <pybind11/gil.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include "IndexMap.h"
 #include "Reader.h"
+#include "UrlStream.h"
 #include "exceptions.h"
 #include "inc_libCZI.h"
 
@@ -12,6 +14,7 @@
 #include "pb_caster_ImagesContainer.h"
 #include "pb_caster_SubblockMetaVec.h"
 #include "pb_caster_libCZI_DimensionIndex.h"
+#include "pb_stream_options.h"
 
 PYBIND11_MODULE(_aicspylibczi, m)
 {
@@ -36,27 +39,52 @@ PYBIND11_MODULE(_aicspylibczi, m)
   py::register_exception<pylibczi::CDimCoordinatesUnderspecifiedException>(
     m, "PylibCZI_CDimCoordinatesUnderspecifiedException");
 
+  m.def("curl_stream_available",
+        &pylibczi::curlStreamAvailable,
+        "True if this build can read CZI files from http/https URLs.");
+  m.def("stream_option_names",
+        &pylibczi::streamOptionNames,
+        "The libCZI property names accepted as stream options by Reader.from_url.");
+
+  // Every Reader call releases the GIL: any of them may read from the stream, which for a
+  // remote file means blocking on the network. Reader itself never touches the Python API -
+  // that is confined to the pybind11 casters, which run before and after the guard.
+  using ReleaseGil = py::call_guard<py::gil_scoped_release>;
+
   py::class_<pylibczi::Reader>(m, "Reader")
-    .def(py::init<std::shared_ptr<libCZI::IStream>>())
-    .def("is_mosaic", &pylibczi::Reader::isMosaic)
-    .def("has_consistent_shape", &pylibczi::Reader::shapeIsConsistent)
-    .def("read_dims", &pylibczi::Reader::readDimsRange)
-    .def("read_dims_string", &pylibczi::Reader::dimsString)
-    .def("read_dims_sizes", &pylibczi::Reader::dimSizes)
-    .def("read_meta", &pylibczi::Reader::readMeta)
-    .def("read_selected", &pylibczi::Reader::readSelected)
-    .def("read_meta_from_subblock", &pylibczi::Reader::readSubblockMeta)
-    .def("read_mosaic", &pylibczi::Reader::readMosaic)
-    .def("read_tile_bounding_box", &pylibczi::Reader::tileBoundingBox)
-    .def("read_scene_bounding_box", &pylibczi::Reader::sceneBoundingBox)
-    .def("read_all_tile_bounding_boxes", &pylibczi::Reader::tileBoundingBoxes)
-    .def("read_all_scene_bounding_boxes", &pylibczi::Reader::allSceneBoundingBoxes)
-    .def("read_mosaic_bounding_box", &pylibczi::Reader::mosaicBoundingBox)
-    .def("read_mosaic_tile_bounding_box", &pylibczi::Reader::mosaicTileBoundingBox)
-    .def("read_mosaic_scene_bounding_box", &pylibczi::Reader::mosaicSceneBoundingBox)
-    .def("read_all_mosaic_tile_bounding_boxes", &pylibczi::Reader::mosaicTileBoundingBoxes)
-    .def("read_all_mosaic_scene_bounding_boxes", &pylibczi::Reader::allMosaicSceneBoundingBoxes)
-    .def_property_readonly("pixel_type", &pylibczi::Reader::pixelType);
+    .def(py::init<std::shared_ptr<libCZI::IStream>>(), ReleaseGil())
+    .def_static(
+      "from_url",
+      [](const std::string& url_, const py::dict& options_) {
+        pylibczi::throwIfCurlStreamUnavailable();
+        auto propertyBag = pb_helpers::streamPropertyBagFromDict(options_);
+        py::gil_scoped_release release;
+        auto stream = pylibczi::createStreamFromUrl(url_, propertyBag);
+        return std::unique_ptr<pylibczi::Reader>(new pylibczi::Reader(std::move(stream)));
+      },
+      py::arg("url"),
+      py::arg("options") = py::dict(),
+      "Open a CZI file from an http/https URL.")
+    .def("is_mosaic", &pylibczi::Reader::isMosaic, ReleaseGil())
+    .def("has_consistent_shape", &pylibczi::Reader::shapeIsConsistent, ReleaseGil())
+    .def("read_dims", &pylibczi::Reader::readDimsRange, ReleaseGil())
+    .def("read_dims_string", &pylibczi::Reader::dimsString, ReleaseGil())
+    .def("read_dims_sizes", &pylibczi::Reader::dimSizes, ReleaseGil())
+    .def("read_meta", &pylibczi::Reader::readMeta, ReleaseGil())
+    .def("read_selected", &pylibczi::Reader::readSelected, ReleaseGil())
+    .def("read_meta_from_subblock", &pylibczi::Reader::readSubblockMeta, ReleaseGil())
+    .def("read_mosaic", &pylibczi::Reader::readMosaic, ReleaseGil())
+    .def("read_tile_bounding_box", &pylibczi::Reader::tileBoundingBox, ReleaseGil())
+    .def("read_scene_bounding_box", &pylibczi::Reader::sceneBoundingBox, ReleaseGil())
+    .def("read_all_tile_bounding_boxes", &pylibczi::Reader::tileBoundingBoxes, ReleaseGil())
+    .def("read_all_scene_bounding_boxes", &pylibczi::Reader::allSceneBoundingBoxes, ReleaseGil())
+    .def("read_mosaic_bounding_box", &pylibczi::Reader::mosaicBoundingBox, ReleaseGil())
+    .def("read_mosaic_tile_bounding_box", &pylibczi::Reader::mosaicTileBoundingBox, ReleaseGil())
+    .def("read_mosaic_scene_bounding_box", &pylibczi::Reader::mosaicSceneBoundingBox, ReleaseGil())
+    .def("read_all_mosaic_tile_bounding_boxes", &pylibczi::Reader::mosaicTileBoundingBoxes, ReleaseGil())
+    .def(
+      "read_all_mosaic_scene_bounding_boxes", &pylibczi::Reader::allMosaicSceneBoundingBoxes, ReleaseGil())
+    .def_property_readonly("pixel_type", &pylibczi::Reader::pixelType, ReleaseGil());
 
   py::class_<pylibczi::IndexMap>(m, "IndexMap")
     .def(py::init<>())

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -51,6 +51,19 @@ PYBIND11_MODULE(_aicspylibczi, m)
   // that is confined to the pybind11 casters, which run before and after the guard.
   using ReleaseGil = py::call_guard<py::gil_scoped_release>;
 
+  // BBox is registered before Reader because pybind11 converts py::arg default values at .def()
+  // time, and Reader::read_selected takes a default-valued IntRect region.
+  py::class_<libCZI::IntRect>(m, "BBox")
+    .def(py::init<>())
+    .def("__eq__",
+         [](const libCZI::IntRect& a, const libCZI::IntRect& b) {
+           return (a.x == b.x && a.y == b.y && a.w == b.w && a.h == b.h);
+         })
+    .def_readwrite("x", &libCZI::IntRect::x)
+    .def_readwrite("y", &libCZI::IntRect::y)
+    .def_readwrite("w", &libCZI::IntRect::w)
+    .def_readwrite("h", &libCZI::IntRect::h);
+
   py::class_<pylibczi::Reader>(m, "Reader")
     .def(py::init<std::shared_ptr<libCZI::IStream>>(), ReleaseGil())
     .def_static(
@@ -71,7 +84,15 @@ PYBIND11_MODULE(_aicspylibczi, m)
     .def("read_dims_string", &pylibczi::Reader::dimsString, ReleaseGil())
     .def("read_dims_sizes", &pylibczi::Reader::dimSizes, ReleaseGil())
     .def("read_meta", &pylibczi::Reader::readMeta, ReleaseGil())
-    .def("read_selected", &pylibczi::Reader::readSelected, ReleaseGil())
+    // Defaults are spelled out here so existing three-argument calls keep working now that
+    // readSelected takes a region.
+    .def("read_selected",
+         &pylibczi::Reader::readSelected,
+         py::arg("plane_coord"),
+         py::arg("index_m") = -1,
+         py::arg("cores") = 3,
+         py::arg("region") = libCZI::IntRect{ 0, 0, -1, -1 },
+         ReleaseGil())
     .def("read_meta_from_subblock", &pylibczi::Reader::readSubblockMeta, ReleaseGil())
     .def("read_mosaic", &pylibczi::Reader::readMosaic, ReleaseGil())
     .def("read_tile_bounding_box", &pylibczi::Reader::tileBoundingBox, ReleaseGil())
@@ -93,17 +114,6 @@ PYBIND11_MODULE(_aicspylibczi, m)
     .def("m_index", &pylibczi::IndexMap::mIndex);
 
   py::class_<libCZI::CDimCoordinate>(m, "DimCoord").def(py::init<>()).def("set_dim", &libCZI::CDimCoordinate::Set);
-
-  py::class_<libCZI::IntRect>(m, "BBox")
-    .def(py::init<>())
-    .def("__eq__",
-         [](const libCZI::IntRect& a, const libCZI::IntRect& b) {
-           return (a.x == b.x && a.y == b.y && a.w == b.w && a.h == b.h);
-         })
-    .def_readwrite("x", &libCZI::IntRect::x)
-    .def_readwrite("y", &libCZI::IntRect::y)
-    .def_readwrite("w", &libCZI::IntRect::w)
-    .def_readwrite("h", &libCZI::IntRect::h);
 
   py::class_<libCZI::RgbFloatColor>(m, "RgbFloat")
     .def(py::init<>())

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -46,6 +46,9 @@ PYBIND11_MODULE(_aicspylibczi, m)
         &pylibczi::streamOptionNames,
         "The libCZI property names accepted as stream options by Reader.from_url.");
 
+  // Releases the GIL for the duration of the bound C++ call so a slow read
+  // (e.g. an HTTP range request on a remote CZI) doesn't stall other Python
+  // threads. See https://pybind11.readthedocs.io/en/stable/advanced/misc.html#global-interpreter-lock-gil
   using ReleaseGil = py::call_guard<py::gil_scoped_release>;
 
   py::class_<libCZI::IntRect>(m, "BBox")

--- a/_aicspylibczi/pb_stream_options.h
+++ b/_aicspylibczi/pb_stream_options.h
@@ -12,13 +12,7 @@
 
 namespace pb_helpers {
 
-/*!
- * @brief Convert a python value to a libCZI stream property of the requested type.
- * @param value_ the python value
- * @param type_ the type libCZI expects for this property
- * @param name_ the option name, used for error messages
- * @return the typed property
- */
+/// @brief Convert a python value to a libCZI stream property of the requested type.
 inline libCZI::StreamsFactory::Property
 streamPropertyFromPyObject(const pybind11::handle& value_,
                            libCZI::StreamsFactory::Property::Type type_,
@@ -50,15 +44,7 @@ streamPropertyFromPyObject(const pybind11::handle& value_,
   throw std::invalid_argument(msg.str());
 }
 
-/*!
- * @brief Convert a python dict of stream options into a libCZI property bag.
- *
- * Keys may be either the full libCZI property name ("CurlHttp_Timeout") or its suffix
- * ("timeout"), case-insensitively.
- *
- * @param options_ the options dict
- * @return the property bag to hand to libCZI's StreamsFactory
- */
+/// @brief Convert a python dict of stream options into a libCZI property bag.
 inline std::map<int, libCZI::StreamsFactory::Property>
 streamPropertyBagFromDict(const pybind11::dict& options_)
 {

--- a/_aicspylibczi/pb_stream_options.h
+++ b/_aicspylibczi/pb_stream_options.h
@@ -1,0 +1,86 @@
+#ifndef _AICSPYLIBCZI_PB_STREAM_OPTIONS_H
+#define _AICSPYLIBCZI_PB_STREAM_OPTIONS_H
+
+#include <map>
+#include <sstream>
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+#include "UrlStream.h"
+#include "inc_libCZI.h"
+
+namespace pb_helpers {
+
+/*!
+ * @brief Convert a python value to a libCZI stream property of the requested type.
+ * @param value_ the python value
+ * @param type_ the type libCZI expects for this property
+ * @param name_ the option name, used for error messages
+ * @return the typed property
+ */
+inline libCZI::StreamsFactory::Property
+streamPropertyFromPyObject(const pybind11::handle& value_,
+                           libCZI::StreamsFactory::Property::Type type_,
+                           const std::string& name_)
+{
+  using Type = libCZI::StreamsFactory::Property::Type;
+  try {
+    switch (type_) {
+      case Type::Int32:
+        return libCZI::StreamsFactory::Property(value_.cast<std::int32_t>());
+      case Type::Float:
+        return libCZI::StreamsFactory::Property(value_.cast<float>());
+      case Type::Double:
+        return libCZI::StreamsFactory::Property(value_.cast<double>());
+      case Type::Boolean:
+        return libCZI::StreamsFactory::Property(value_.cast<bool>());
+      case Type::String:
+        return libCZI::StreamsFactory::Property(value_.cast<std::string>());
+      default:
+        break;
+    }
+  } catch (const pybind11::cast_error&) {
+    std::ostringstream msg;
+    msg << "Stream option '" << name_ << "' could not be converted to the type libCZI expects for it.";
+    throw std::invalid_argument(msg.str());
+  }
+  std::ostringstream msg;
+  msg << "Stream option '" << name_ << "' has a type that is not supported.";
+  throw std::invalid_argument(msg.str());
+}
+
+/*!
+ * @brief Convert a python dict of stream options into a libCZI property bag.
+ *
+ * Keys may be either the full libCZI property name ("CurlHttp_Timeout") or its suffix
+ * ("timeout"), case-insensitively.
+ *
+ * @param options_ the options dict
+ * @return the property bag to hand to libCZI's StreamsFactory
+ */
+inline std::map<int, libCZI::StreamsFactory::Property>
+streamPropertyBagFromDict(const pybind11::dict& options_)
+{
+  std::map<int, libCZI::StreamsFactory::Property> propertyBag;
+  for (const auto& item : options_) {
+    const auto name = item.first.cast<std::string>();
+    const auto resolved = pylibczi::resolveStreamOption(name);
+    if (resolved.first < 0) {
+      std::ostringstream msg;
+      msg << "Unknown stream option '" << name << "'. Known options are: ";
+      const auto known = pylibczi::streamOptionNames();
+      for (auto it = known.begin(); it != known.end(); ++it) {
+        msg << (it == known.begin() ? "" : ", ") << *it;
+      }
+      msg << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    propertyBag.emplace(resolved.first, streamPropertyFromPyObject(item.second, resolved.second, name));
+  }
+  return propertyBag;
+}
+
+}
+
+#endif //_AICSPYLIBCZI_PB_STREAM_OPTIONS_H

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -16,9 +16,6 @@ def remote_reads_available() -> bool:
     """
     Test whether this installation can read CZI files from http/https URLs.
 
-    Remote reads require that libCZI was compiled with its curl-based stream class,
-    which is a build-time option.
-
     Returns
     -------
     bool
@@ -469,7 +466,6 @@ class CziFile(object):
         """
         if not isinstance(file, str):
             return False
-        # only http/https, so a Windows drive letter is not mistaken for a URL scheme
         return urlparse(file).scheme.lower() in CziFile.REMOTE_SCHEMES
 
     @staticmethod
@@ -572,10 +568,7 @@ class CziFile(object):
         Parameters
         ----------
         region: Tuple
-            The (x, y, width, height) of a sub-region to restrict the read to, in the same global
-            pixel frame as read_mosaic's region and the tile bounding boxes -- for a mosaic file
-            this is NOT the tile-local frame. Subblocks that do not intersect it are skipped
-            without being read. The default of None reads every matching subblock.
+            The (x, y, width, height) of a sub-region to restrict the read.
         **kwargs
             The keywords below allow you to specify the dimensions that you wish to match. If you
             under-specify the constraints you can easily end up with a massive image stack.
@@ -604,11 +597,6 @@ class CziFile(object):
         The M Dimension is a representation of the m_index used inside libCZI. Unfortunately this can be sparsely
         packed for a given selection which causes problems when indexing memory. Consequently the M Dimension may
         not match the m_index that is being used in libCZI or displayed in Zeiss' Zen software.
-
-        Region selection is by subblock and not by pixel, so a subblock that merely clips the region is
-        returned whole. A region that excludes some tiles also shortens M, so use
-        read_all_mosaic_tile_bounding_boxes filtered by the same region to recover which tile is which.
-
         """
         plane_constraints = self._get_coords_from_kwargs(kwargs)
         m_index = self._get_m_index_from_kwargs(kwargs)
@@ -690,8 +678,6 @@ class CziFile(object):
     def _bbox_from_region(self, region: Tuple = None):
         """
         Convert an (x, y, width, height) tuple into the BBox the C++ layer expects.
-
-        None is encoded as a width and height of -1, which the C++ side reads as the whole image.
         """
         bbox = self.czilib.BBox()
         if region is None:

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -562,7 +562,7 @@ class CziFile(object):
             root.append(new_element)
         return root
 
-    def read_image(self, **kwargs):
+    def read_image(self, region: Tuple = None, **kwargs):
         """
         Read the subblocks in the CZI file and for any subblocks that match all the constraints in kwargs return
         that data. This allows you to select channels/scenes/time-points/Z-slices etc. Note if passed a BGR image
@@ -572,6 +572,12 @@ class CziFile(object):
 
         Parameters
         ----------
+        region: Tuple
+            The (x, y, width, height) of a sub-region to restrict the read to, in the file's global
+            pixel coordinate frame -- the same frame as read_mosaic's region and as the tile bounding
+            boxes, which for a mosaic file is NOT the tile-local frame. Subblocks that do not
+            intersect it are skipped without being read, so for a file being read over the network
+            their bytes never cross the wire. The default of None reads every matching subblock.
         **kwargs
             The keywords below allow you to specify the dimensions that you wish to match. If you
             under-specify the constraints you can easily end up with a massive image stack.
@@ -601,12 +607,20 @@ class CziFile(object):
         packed for a given selection which causes problems when indexing memory. Consequently the M Dimension may
         not match the m_index that is being used in libCZI or displayed in Zeiss' Zen software.
 
+        Subblocks, not pixels, are the unit of region selection. A subblock that merely clips the region is
+        returned whole, at its full size -- the saving is in the subblocks not read at all. A region that
+        excludes some tiles also shortens the M dimension, and since M is repacked densely, position i along M
+        no longer corresponds to m_index i. Use read_all_mosaic_tile_bounding_boxes filtered by the same region
+        to recover which tile is which.
+
         """
         plane_constraints = self._get_coords_from_kwargs(kwargs)
         m_index = self._get_m_index_from_kwargs(kwargs)
         cores = self._get_cores_from_kwargs(kwargs)
 
-        image, shape = self.reader.read_selected(plane_constraints, m_index, cores)
+        image, shape = self.reader.read_selected(
+            plane_constraints, m_index, cores, self._bbox_from_region(region)
+        )
         return image, shape
 
     def read_mosaic(
@@ -656,18 +670,7 @@ class CziFile(object):
         """
         plane_constraints = self._get_coords_from_kwargs(kwargs)
 
-        if region is None:
-            region = self.czilib.BBox()
-            region.w = -1
-            region.h = -1
-        else:
-            assert len(region) == 4
-            tmp = self.czilib.BBox()
-            tmp.x = region[0]
-            tmp.y = region[1]
-            tmp.w = region[2]
-            tmp.h = region[3]
-            region = tmp
+        region = self._bbox_from_region(region)
 
         if background_color is None:
             background_color = self.czilib.RgbFloat()
@@ -687,6 +690,26 @@ class CziFile(object):
         )
 
         return img
+
+    def _bbox_from_region(self, region: Tuple = None):
+        """
+        Convert an (x, y, width, height) tuple into the BBox the C++ layer expects.
+
+        None means "no spatial constraint" and is encoded as a width and height of -1, which the
+        C++ side resolves to the whole image.
+        """
+        bbox = self.czilib.BBox()
+        if region is None:
+            bbox.w = -1
+            bbox.h = -1
+            return bbox
+
+        assert len(region) == 4
+        bbox.x = region[0]
+        bbox.y = region[1]
+        bbox.w = region[2]
+        bbox.h = region[3]
+        return bbox
 
     def _get_coords_from_kwargs(self, kwargs):
         plane_constraints = self.czilib.DimCoord()

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -469,8 +469,7 @@ class CziFile(object):
         """
         if not isinstance(file, str):
             return False
-        # Only http/https are checked so that Windows drive letters, ie "C:\\img.czi",
-        # are not mistaken for a URL scheme.
+        # only http/https, so a Windows drive letter is not mistaken for a URL scheme
         return urlparse(file).scheme.lower() in CziFile.REMOTE_SCHEMES
 
     @staticmethod
@@ -573,11 +572,10 @@ class CziFile(object):
         Parameters
         ----------
         region: Tuple
-            The (x, y, width, height) of a sub-region to restrict the read to, in the file's global
-            pixel coordinate frame -- the same frame as read_mosaic's region and as the tile bounding
-            boxes, which for a mosaic file is NOT the tile-local frame. Subblocks that do not
-            intersect it are skipped without being read, so for a file being read over the network
-            their bytes never cross the wire. The default of None reads every matching subblock.
+            The (x, y, width, height) of a sub-region to restrict the read to, in the same global
+            pixel frame as read_mosaic's region and the tile bounding boxes -- for a mosaic file
+            this is NOT the tile-local frame. Subblocks that do not intersect it are skipped
+            without being read. The default of None reads every matching subblock.
         **kwargs
             The keywords below allow you to specify the dimensions that you wish to match. If you
             under-specify the constraints you can easily end up with a massive image stack.
@@ -607,11 +605,9 @@ class CziFile(object):
         packed for a given selection which causes problems when indexing memory. Consequently the M Dimension may
         not match the m_index that is being used in libCZI or displayed in Zeiss' Zen software.
 
-        Subblocks, not pixels, are the unit of region selection. A subblock that merely clips the region is
-        returned whole, at its full size -- the saving is in the subblocks not read at all. A region that
-        excludes some tiles also shortens the M dimension, and since M is repacked densely, position i along M
-        no longer corresponds to m_index i. Use read_all_mosaic_tile_bounding_boxes filtered by the same region
-        to recover which tile is which.
+        Region selection is by subblock and not by pixel, so a subblock that merely clips the region is
+        returned whole. A region that excludes some tiles also shortens M, so use
+        read_all_mosaic_tile_bounding_boxes filtered by the same region to recover which tile is which.
 
         """
         plane_constraints = self._get_coords_from_kwargs(kwargs)
@@ -695,8 +691,7 @@ class CziFile(object):
         """
         Convert an (x, y, width, height) tuple into the BBox the C++ layer expects.
 
-        None means "no spatial constraint" and is encoded as a width and height of -1, which the
-        C++ side resolves to the whole image.
+        None is encoded as a width and height of -1, which the C++ side reads as the whole image.
         """
         bbox = self.czilib.BBox()
         if region is None:

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -3,7 +3,8 @@
 import io
 import multiprocessing
 from pathlib import Path
-from typing import BinaryIO, Tuple, Union
+from typing import BinaryIO, Dict, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 import numpy as np
 import xml.etree.ElementTree as ET
@@ -11,14 +12,33 @@ import xml.etree.ElementTree as ET
 from . import types
 
 
+def remote_reads_available() -> bool:
+    """
+    Test whether this installation can read CZI files from http/https URLs.
+
+    Remote reads require that libCZI was compiled with its curl-based stream class,
+    which is a build-time option.
+
+    Returns
+    -------
+    bool
+        True if CziFile accepts http/https URLs.
+
+    """
+    import _aicspylibczi
+
+    return _aicspylibczi.curl_stream_available()
+
+
 class CziFile(object):
     """Zeiss CZI file object.
 
     Args:
-      |  czi_filename (str): Filename of czifile to access.
+      |  czi_filename (str): Filename of czifile to access, or an http/https URL.
 
     Kwargs:
       |  verbose (bool): Print information and times during czi file access.
+      |  stream_options (dict): libCZI stream options, only valid for URLs.
 
     .. note::
 
@@ -48,19 +68,34 @@ class CziFile(object):
     ####
     ZISRAW_DIMS = {"Z", "C", "T", "R", "S", "I", "H", "V", "B"}
 
+    REMOTE_SCHEMES = frozenset({"http", "https"})
+
     def __init__(
         self,
         czi_filename: types.FileLike,
         verbose: bool = False,
+        stream_options: Optional[Dict[str, Union[str, int, bool]]] = None,
     ):
-        # Convert to BytesIO (bytestream)
-        self._bytes = self.convert_to_buffer(czi_filename)
         self.czifile_verbose = verbose
 
         import _aicspylibczi
 
         self.czilib = _aicspylibczi
-        self.reader = self.czilib.Reader(self._bytes)
+
+        if self.is_remote(czi_filename):
+            self._bytes = None
+            self.reader = self.czilib.Reader.from_url(
+                str(czi_filename), stream_options or {}
+            )
+        else:
+            if stream_options:
+                raise ValueError(
+                    "stream_options are only supported for http/https URLs, "
+                    f"received: {czi_filename}"
+                )
+            # Convert to BytesIO (bytestream)
+            self._bytes = self.convert_to_buffer(czi_filename)
+            self.reader = self.czilib.Reader(self._bytes)
 
         self.meta_root = None
 
@@ -415,6 +450,28 @@ class CziFile(object):
 
         """
         return self.reader.is_mosaic()
+
+    @staticmethod
+    def is_remote(file: types.FileLike) -> bool:
+        """
+        Test if the given target is an http/https URL rather than a local file.
+
+        Parameters
+        ----------
+        file
+            The target passed to the constructor.
+
+        Returns
+        -------
+        bool
+            True if the target is an http or https URL.
+
+        """
+        if not isinstance(file, str):
+            return False
+        # Only http/https are checked so that Windows drive letters, ie "C:\\img.czi",
+        # are not mistaken for a URL scheme.
+        return urlparse(file).scheme.lower() in CziFile.REMOTE_SCHEMES
 
     @staticmethod
     def convert_to_buffer(file: types.FileLike) -> Union[BinaryIO, np.ndarray]:

--- a/aicspylibczi/__init__.py
+++ b/aicspylibczi/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["CziFile"]
-from .CziFile import CziFile
+__all__ = ["CziFile", "remote_reads_available"]
+from .CziFile import CziFile, remote_reads_available
 from ._version import __version__  # noqa F401

--- a/aicspylibczi/tests/conftest.py
+++ b/aicspylibczi/tests/conftest.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import threading
+from functools import partial
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -9,3 +12,85 @@ import pytest
 @pytest.fixture
 def data_dir() -> Path:
     return Path(__file__).parent / "resources"
+
+
+class RangeRequestHandler(BaseHTTPRequestHandler):
+    """Serves a directory over http with byte-range support.
+
+    libCZI's curl stream reads via Range requests and rejects any response that
+    delivers more bytes than it asked for, so http.server's stock handler (which
+    ignores Range) cannot be used here.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def __init__(self, *args, directory: Path, **kwargs):
+        self._root = directory.resolve()
+        super().__init__(*args, **kwargs)
+
+    def _resolve(self):
+        candidate = (self._root / self.path.lstrip("/")).resolve()
+        if self._root not in candidate.parents or not candidate.is_file():
+            return None
+        return candidate
+
+    def do_GET(self):
+        target = self._resolve()
+        if target is None:
+            self.send_error(404)
+            return
+
+        data = target.read_bytes()
+        range_header = self.headers.get("Range")
+
+        if range_header is None:
+            body = data
+            status = 200
+            content_range = None
+        else:
+            # libCZI sends "bytes=<start>-<end>" with an inclusive end.
+            start_text, _, end_text = range_header.partition("=")[2].partition("-")
+            start = int(start_text)
+            end = int(end_text) if end_text else len(data) - 1
+            end = min(end, len(data) - 1)
+            if start > end:
+                self.send_response(416)
+                self.send_header("Content-Range", f"bytes */{len(data)}")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            stop = end + 1
+            body = data[start:stop]
+            status = 206
+            content_range = f"bytes {start}-{end}/{len(data)}"
+
+        self.send_response(status)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Accept-Ranges", "bytes")
+        if content_range is not None:
+            self.send_header("Content-Range", content_range)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def data_server(data_dir):
+    """Serve the test resources over http, yielding the base URL."""
+    handler = partial(RangeRequestHandler, directory=data_dir)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
+    # libCZI keeps its connection alive, so a handler thread is always parked waiting for
+    # the next request. server_close() would join it and never return.
+    server.block_on_close = False
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/aicspylibczi/tests/conftest.py
+++ b/aicspylibczi/tests/conftest.py
@@ -15,11 +15,7 @@ def data_dir() -> Path:
 
 
 class RangeRequestHandler(BaseHTTPRequestHandler):
-    """Serves a directory over http with byte-range support.
-
-    libCZI's curl stream rejects any response that delivers more bytes than it asked
-    for, so http.server's stock handler, which ignores Range, cannot be used here.
-    """
+    """Serves a directory over http with byte-range support."""
 
     protocol_version = "HTTP/1.1"
 

--- a/aicspylibczi/tests/conftest.py
+++ b/aicspylibczi/tests/conftest.py
@@ -17,9 +17,8 @@ def data_dir() -> Path:
 class RangeRequestHandler(BaseHTTPRequestHandler):
     """Serves a directory over http with byte-range support.
 
-    libCZI's curl stream reads via Range requests and rejects any response that
-    delivers more bytes than it asked for, so http.server's stock handler (which
-    ignores Range) cannot be used here.
+    libCZI's curl stream rejects any response that delivers more bytes than it asked
+    for, so http.server's stock handler, which ignores Range, cannot be used here.
     """
 
     protocol_version = "HTTP/1.1"
@@ -83,8 +82,8 @@ def data_server(data_dir):
     handler = partial(RangeRequestHandler, directory=data_dir)
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     server.daemon_threads = True
-    # libCZI keeps its connection alive, so a handler thread is always parked waiting for
-    # the next request. server_close() would join it and never return.
+    # libCZI keeps the connection alive, so a handler thread is always parked waiting for
+    # the next request and server_close() would join it and never return
     server.block_on_close = False
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -463,20 +463,11 @@ def test_read_image_region_selects_intersecting_subblocks(data_dir, fname):
 
 
 @pytest.mark.parametrize("fname", ["mosaic_test.czi"])
+@pytest.mark.raises(exception=PylibCZI_RegionSelectionException)
 def test_read_image_region_outside_image_raises(data_dir, fname):
     czi = CziFile(str(data_dir / fname))
     bbox = czi.get_mosaic_bounding_box()
-    with pytest.raises(PylibCZI_RegionSelectionException):
-        czi.read_image(C=0, region=(bbox.x + bbox.w + 10, bbox.y, 64, 64))
-
-
-@pytest.mark.parametrize("fname", ["mosaic_test.czi"])
-def test_read_image_without_region_is_unchanged(data_dir, fname):
-    # adding region must not move any pixels for callers that never pass it
-    czi = CziFile(str(data_dir / fname))
-    data, shape = czi.read_image(C=0)
-    assert dict(shape)["M"] == 2
-    assert data.shape[-2:] == (624, 924)
+    czi.read_image(C=0, region=(bbox.x + bbox.w + 10, bbox.y, 64, 64))
 
 
 @pytest.mark.parametrize(
@@ -576,12 +567,10 @@ def test_bgr_plane_data_x(data_dir, fname, p_index, ans_file):
         ("https://example.com/image.czi", True),
         ("http://example.com/image.czi", True),
         ("HTTPS://example.com/image.czi", True),
-        ("/tmp/image.czi", False),
         ("image.czi", False),
         ("C:\\images\\image.czi", False),
         ("s3://bucket/image.czi", False),
         (Path("/tmp/image.czi"), False),
-        (io.BytesIO(b"notaurl"), False),
     ],
 )
 def test_is_remote(target, expected):
@@ -592,20 +581,20 @@ def test_remote_reads_available():
     assert remote_reads_available()
 
 
+@pytest.mark.raises(exception=ValueError)
 def test_stream_options_rejected_for_local_file(data_dir):
-    with pytest.raises(ValueError):
-        CziFile(data_dir / "s_1_t_1_c_1_z_1.czi", stream_options={"timeout": 30})
+    CziFile(data_dir / "s_1_t_1_c_1_z_1.czi", stream_options={"timeout": 30})
 
 
-def test_unknown_stream_option(data_server):
-    with pytest.raises(ValueError):
-        CziFile(f"{data_server}/s_1_t_1_c_1_z_1.czi", stream_options={"nonsense": 1})
+@pytest.mark.raises(exception=ValueError)
+def test_unknown_stream_option():
+    # rejected while building the property bag, so no server is contacted
+    CziFile("https://example.com/image.czi", stream_options={"nonsense": 1})
 
 
 @pytest.mark.parametrize(
     "options",
     [
-        {},
         {"timeout": 30},
         {"CurlHttp_Timeout": 30},
         {"connect_timeout": 10, "follow_location": True, "user_agent": "aicspylibczi"},
@@ -616,9 +605,7 @@ def test_remote_stream_options(data_server, options):
     assert czi.dims == "BCYX"
 
 
-@pytest.mark.parametrize(
-    "fname", ["s_1_t_1_c_1_z_1.czi", "s_3_t_1_c_3_z_5.czi", "RGB-8bit.czi"]
-)
+@pytest.mark.parametrize("fname", ["s_1_t_1_c_1_z_1.czi", "s_3_t_1_c_3_z_5.czi"])
 def test_remote_matches_local(data_dir, data_server, fname):
     remote = CziFile(f"{data_server}/{fname}")
     with open(data_dir / fname, "rb") as fp:
@@ -650,6 +637,6 @@ def test_remote_mosaic(data_dir, data_server):
     np.testing.assert_array_equal(remote_img, local_img)
 
 
+@pytest.mark.raises(exception=RuntimeError)
 def test_remote_missing_file(data_server):
-    with pytest.raises(RuntimeError):
-        CziFile(f"{data_server}/does_not_exist.czi")
+    CziFile(f"{data_server}/does_not_exist.czi")

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -3,8 +3,9 @@ import numpy as np
 import pytest
 import xml.etree.ElementTree as ET
 
+from pathlib import Path
 
-from aicspylibczi import CziFile
+from aicspylibczi import CziFile, remote_reads_available
 from _aicspylibczi import PylibCZI_CDimCoordinatesOverspecifiedException
 
 
@@ -526,3 +527,88 @@ def test_bgr_plane_data_x(data_dir, fname, p_index, ans_file):
         img, dims = czi.read_image()
         assert img[0, :, :, p_index].shape == ans.shape
         np.testing.assert_array_almost_equal(img[0, :, :, p_index], ans)
+
+
+@pytest.mark.parametrize(
+    "target, expected",
+    [
+        ("https://example.com/image.czi", True),
+        ("http://example.com/image.czi", True),
+        ("HTTPS://example.com/image.czi", True),
+        ("/tmp/image.czi", False),
+        ("image.czi", False),
+        ("C:\\images\\image.czi", False),
+        ("s3://bucket/image.czi", False),
+        (Path("/tmp/image.czi"), False),
+        (io.BytesIO(b"notaurl"), False),
+    ],
+)
+def test_is_remote(target, expected):
+    assert CziFile.is_remote(target) == expected
+
+
+def test_remote_reads_available():
+    assert remote_reads_available()
+
+
+def test_stream_options_rejected_for_local_file(data_dir):
+    with pytest.raises(ValueError):
+        CziFile(data_dir / "s_1_t_1_c_1_z_1.czi", stream_options={"timeout": 30})
+
+
+def test_unknown_stream_option(data_server):
+    with pytest.raises(ValueError):
+        CziFile(f"{data_server}/s_1_t_1_c_1_z_1.czi", stream_options={"nonsense": 1})
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {},
+        {"timeout": 30},
+        {"CurlHttp_Timeout": 30},
+        {"connect_timeout": 10, "follow_location": True, "user_agent": "aicspylibczi"},
+    ],
+)
+def test_remote_stream_options(data_server, options):
+    czi = CziFile(f"{data_server}/s_1_t_1_c_1_z_1.czi", stream_options=options)
+    assert czi.dims == "BCYX"
+
+
+@pytest.mark.parametrize(
+    "fname", ["s_1_t_1_c_1_z_1.czi", "s_3_t_1_c_3_z_5.czi", "RGB-8bit.czi"]
+)
+def test_remote_matches_local(data_dir, data_server, fname):
+    remote = CziFile(f"{data_server}/{fname}")
+    with open(data_dir / fname, "rb") as fp:
+        local = CziFile(czi_filename=fp)
+
+        assert remote.dims == local.dims
+        assert remote.size == local.size
+        assert remote.pixel_type == local.pixel_type
+        assert remote.get_dims_shape() == local.get_dims_shape()
+        assert ET.tostring(remote.meta) == ET.tostring(local.meta)
+
+        remote_img, remote_shape = remote.read_image()
+        local_img, local_shape = local.read_image()
+
+    assert remote_shape == local_shape
+    np.testing.assert_array_equal(remote_img, local_img)
+
+
+def test_remote_mosaic(data_dir, data_server):
+    remote = CziFile(f"{data_server}/mosaic_test.czi")
+    with open(data_dir / "mosaic_test.czi", "rb") as fp:
+        local = CziFile(czi_filename=fp)
+
+        assert remote.is_mosaic()
+        assert remote.get_mosaic_bounding_box() == local.get_mosaic_bounding_box()
+        remote_img = remote.read_mosaic(scale_factor=1.0, C=0)
+        local_img = local.read_mosaic(scale_factor=1.0, C=0)
+
+    np.testing.assert_array_equal(remote_img, local_img)
+
+
+def test_remote_missing_file(data_server):
+    with pytest.raises(RuntimeError):
+        CziFile(f"{data_server}/does_not_exist.czi")

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -6,7 +6,10 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from aicspylibczi import CziFile, remote_reads_available
-from _aicspylibczi import PylibCZI_CDimCoordinatesOverspecifiedException
+from _aicspylibczi import (
+    PylibCZI_CDimCoordinatesOverspecifiedException,
+    PylibCZI_RegionSelectionException,
+)
 
 
 @pytest.mark.parametrize(
@@ -436,6 +439,48 @@ def test_mosaic_image(data_dir, fname, unscaled_size, expects):
         assert img.shape[0] == 1
         assert img.shape[1] == unscaled_size[3] // 10
         assert img.shape[2] == unscaled_size[2] // 10
+
+
+@pytest.mark.parametrize("fname", ["mosaic_test.czi"])
+def test_read_image_region_selects_intersecting_subblocks(data_dir, fname):
+    # mosaic_test.czi is two tiles side by side, overlapping in the middle. A region
+    # inside the left tile only must not pull the right one: skipping a subblock is
+    # what saves a range request when the file is remote.
+    czi = CziFile(str(data_dir / fname))
+    bbox = czi.get_mosaic_bounding_box()
+
+    _, all_tiles = czi.read_image(C=0)
+    assert dict(all_tiles)["M"] == 2
+
+    data, shape = czi.read_image(C=0, region=(bbox.x, bbox.y, 64, 64))
+    assert dict(shape)["M"] == 1
+
+    # Subblocks are the unit of selection, so the tile comes back whole rather than
+    # cropped to the region.
+    assert dict(shape)["Y"] == dict(all_tiles)["Y"]
+    assert dict(shape)["X"] == dict(all_tiles)["X"]
+
+    # ...and it is the tile the region actually lands in.
+    left_tile, _ = czi.read_image(C=0, M=0)
+    assert np.array_equal(data, left_tile)
+
+
+@pytest.mark.parametrize("fname", ["mosaic_test.czi"])
+def test_read_image_region_outside_image_raises(data_dir, fname):
+    czi = CziFile(str(data_dir / fname))
+    bbox = czi.get_mosaic_bounding_box()
+    with pytest.raises(PylibCZI_RegionSelectionException):
+        czi.read_image(C=0, region=(bbox.x + bbox.w + 10, bbox.y, 64, 64))
+
+
+@pytest.mark.parametrize("fname", ["mosaic_test.czi"])
+def test_read_image_without_region_is_unchanged(data_dir, fname):
+    # The region argument defaults to None, and adding it must not have moved any
+    # pixels for callers that never pass it.
+    czi = CziFile(str(data_dir / fname))
+    data, shape = czi.read_image(C=0)
+    assert dict(shape)["M"] == 2
+    assert data.shape[-2:] == (624, 924)
 
 
 @pytest.mark.parametrize(

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -443,7 +443,6 @@ def test_mosaic_image(data_dir, fname, unscaled_size, expects):
 
 @pytest.mark.parametrize("fname", ["mosaic_test.czi"])
 def test_read_image_region_selects_intersecting_subblocks(data_dir, fname):
-    # mosaic_test.czi is two tiles side by side, overlapping in the middle
     czi = CziFile(str(data_dir / fname))
     bbox = czi.get_mosaic_bounding_box()
 
@@ -453,11 +452,9 @@ def test_read_image_region_selects_intersecting_subblocks(data_dir, fname):
     data, shape = czi.read_image(C=0, region=(bbox.x, bbox.y, 64, 64))
     assert dict(shape)["M"] == 1
 
-    # selection is by subblock, so the tile comes back whole rather than cropped
     assert dict(shape)["Y"] == dict(all_tiles)["Y"]
     assert dict(shape)["X"] == dict(all_tiles)["X"]
 
-    # ...and it is the tile the region lands in
     left_tile, _ = czi.read_image(C=0, M=0)
     assert np.array_equal(data, left_tile)
 
@@ -588,7 +585,6 @@ def test_stream_options_rejected_for_local_file(data_dir):
 
 @pytest.mark.raises(exception=ValueError)
 def test_unknown_stream_option():
-    # rejected while building the property bag, so no server is contacted
     CziFile("https://example.com/image.czi", stream_options={"nonsense": 1})
 
 

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -443,9 +443,7 @@ def test_mosaic_image(data_dir, fname, unscaled_size, expects):
 
 @pytest.mark.parametrize("fname", ["mosaic_test.czi"])
 def test_read_image_region_selects_intersecting_subblocks(data_dir, fname):
-    # mosaic_test.czi is two tiles side by side, overlapping in the middle. A region
-    # inside the left tile only must not pull the right one: skipping a subblock is
-    # what saves a range request when the file is remote.
+    # mosaic_test.czi is two tiles side by side, overlapping in the middle
     czi = CziFile(str(data_dir / fname))
     bbox = czi.get_mosaic_bounding_box()
 
@@ -455,12 +453,11 @@ def test_read_image_region_selects_intersecting_subblocks(data_dir, fname):
     data, shape = czi.read_image(C=0, region=(bbox.x, bbox.y, 64, 64))
     assert dict(shape)["M"] == 1
 
-    # Subblocks are the unit of selection, so the tile comes back whole rather than
-    # cropped to the region.
+    # selection is by subblock, so the tile comes back whole rather than cropped
     assert dict(shape)["Y"] == dict(all_tiles)["Y"]
     assert dict(shape)["X"] == dict(all_tiles)["X"]
 
-    # ...and it is the tile the region actually lands in.
+    # ...and it is the tile the region lands in
     left_tile, _ = czi.read_image(C=0, M=0)
     assert np.array_equal(data, left_tile)
 
@@ -475,8 +472,7 @@ def test_read_image_region_outside_image_raises(data_dir, fname):
 
 @pytest.mark.parametrize("fname", ["mosaic_test.czi"])
 def test_read_image_without_region_is_unchanged(data_dir, fname):
-    # The region argument defaults to None, and adding it must not have moved any
-    # pixels for callers that never pass it.
+    # adding region must not move any pixels for callers that never pass it
     czi = CziFile(str(data_dir / fname))
     data, shape = czi.read_image(C=0)
     assert dict(shape)["M"] == 2


### PR DESCRIPTION
Resolves #134.

This PR implements a way for `CziFile` to accept a `http`/`https` URL in place of a path, backed by libCZI's curl stream. Reads fetch only the byte ranges they need rather than downloading the file, so tile and plane access stays cheap on large remote images.

```python
from aicspylibczi import CziFile

# any range-capable https URL, including presigned S3/GCS/Azure links
czi = CziFile("https://example.com/image.czi")
img, shp = czi.read_image(S=0, C=0)

# authenticated or slow endpoints
czi = CziFile(
    "https://example.com/private.czi",
    stream_options={"timeout": 60, "xoauth2_bearer": my_token},
)

# a region reads only the tiles it touches -- 24-tile mosaic plane served from S3
czi = CziFile(my_presigned_url)
bbox = czi.get_mosaic_bounding_box()
czi.read_image(C=0, T=0, Z=0)                                   # 7.97s, M=24
czi.read_image(C=0, T=0, Z=0, region=(bbox.x, bbox.y, 64, 64))  # 0.27s, M=1
```
## Testing
I tested this with https://github.com/bioio-devs/bioio-czi/pull/113 to remote read czis from BFF. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Read CZI files directly from HTTP/HTTPS URLs, including authenticated and presigned links.
  - Configure and discover remote stream options.
  - Check whether remote reading is available in the installed build.
  - Limit image reads to a specified rectangular region, including mosaic images.
- **Bug Fixes**
  - Improved validation and error messages for invalid regions, unavailable remote support, and missing remote files.
- **Documentation**
  - Added guidance on remote reading, range-request requirements, TLS dependencies, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->